### PR TITLE
新增数据流相关 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Add following to `AndroidManifest.xml`
 
 | Property                         | Type                                     | Description                           |
 | -------------------------------- | ---------------------------------------- | ------------------------------------- |
-| init                             | object {appid: 'agora注册的应用id', channelProfile: '频道模式', videoProfile: '视频模式', clientRole: '角色', swapWidthAndHeight: 'bool值', reliable: 'bool值 - 默认数据流通道创建参数，参考 createDataStream', ordered: 'bool值 - 默认数据流通道创建参数，参考 createDataStream'} | 初始化Agora引擎                            |
+| init                             | object {appid: 'agora注册的应用id', channelProfile: '频道模式', videoProfile: '视频模式', clientRole: '角色', swapWidthAndHeight: 'bool值'} | 初始化Agora引擎                            |
 | joinChannel                      | string channelName （房间名称）   number uid （用户设置的uid 传0系统会自动分配） | 加入房间                                  |
 | leaveChannel                     |                                          | 离开频道                                  |
 | destroy                          |                                          | 销毁引擎实例                                |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Add following to `AndroidManifest.xml`
 
 | Property                         | Type                                     | Description                           |
 | -------------------------------- | ---------------------------------------- | ------------------------------------- |
-| init                             | object {appid: 'agora注册的应用id', channelProfile: '频道模式', videoProfile: '视频模式', clientRole: '角色', swapWidthAndHeight: 'bool值'} | 初始化Agora引擎                            |
+| init                             | object {appid: 'agora注册的应用id', channelProfile: '频道模式', videoProfile: '视频模式', clientRole: '角色', swapWidthAndHeight: 'bool值', reliable: 'bool值 - 默认数据流通道创建参数，参考 createDataStream', ordered: 'bool值 - 默认数据流通道创建参数，参考 createDataStream'} | 初始化Agora引擎                            |
 | joinChannel                      | string channelName （房间名称）   number uid （用户设置的uid 传0系统会自动分配） | 加入房间                                  |
 | leaveChannel                     |                                          | 离开频道                                  |
 | destroy                          |                                          | 销毁引擎实例                                |
@@ -109,6 +109,8 @@ Add following to `AndroidManifest.xml`
 | startRecordingService (iOS only) | string  recordingKey                     | 启动服务端录制服务                             |
 | stopRecordingService (iOS only)  | string  recordingKey                     | 停止服务端录制服务                             |
 | getSdkVersion                    | callback                                 | 获取版本号                                 |
+| createDataStream | (boolean reliable, boolean ordered, (streamId) => {}), 其中 reliable, ordered 请参考官方文档同名方法说明 | 创建数据流通道 |
+| sendStreamMessage | (number streamId, string message, (errorCode) => {})| 发送数据 |
 
 ##### 原生通知事件
 
@@ -121,7 +123,8 @@ RtcEngine.eventEmitter({
   onError: data => {},
   onWarning: data => {},
   onLeaveChannel: data => {},
-  onAudioVolumeIndication: data => {}
+  onAudioVolumeIndication: data => {},
+  onStreamMessage: ({uid, streamId, data}) => {}
 })
 ```
 
@@ -135,6 +138,7 @@ RtcEngine.eventEmitter({
 | onWarning                 | 警告           |
 | onLeaveChannel            | 退出频道         |
 | onAudioVolumeIndication            | 音量提示回调         |
+| onStreamMessage | 接收到对方数据流消息的回调 |
 
 
 ##### AgoraView 组件
@@ -157,6 +161,12 @@ RtcEngine.eventEmitter({
 
 
 ## 更新信息
+
+#### 1.1.1
+
+- 新增方法 创建数据流通道 createDataStream
+- 新增方法 发送数据流 sendStreamMessage
+- 新增监听数据流事件 onStreamMessage
 
 #### 1.0.9
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ RtcEngine.eventEmitter({
   onWarning: data => {},
   onLeaveChannel: data => {},
   onAudioVolumeIndication: data => {},
-  onStreamMessage: ({uid, streamId, data}) => {}
+  onStreamMessage: ({uid, streamId, data}) => {},
+  onStreamMessageError: ({uid, streamId, error, missed, cached}) => {},
 })
 ```
 
@@ -139,6 +140,7 @@ RtcEngine.eventEmitter({
 | onLeaveChannel            | 退出频道         |
 | onAudioVolumeIndication            | 音量提示回调         |
 | onStreamMessage | 接收到对方数据流消息的回调 |
+| onStreamMessageError | 接收到对方数据流消息错误的回调 |
 
 
 ##### AgoraView 组件

--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -206,7 +206,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void init(ReadableMap options) {
         AgoraManager.getInstance().init(getReactApplicationContext(), mRtcEventHandler, options);
-        this.defaultStreamId = AgoraManager.getInstance().mRtcEngine.createDataStream(options.getBoolean("reliable"), options.getBoolean("ordered"));
+        this.defaultStreamId = AgoraManager.getInstance().mRtcEngine.createDataStream(false, false);
     }
 
     //进入房间

--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -21,6 +21,7 @@ import io.agora.rtc.RtcEngine;
 import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 public class AgoraModule extends ReactContextBaseJavaModule {
+    private int defaultStreamId = -1;
 
     public AgoraModule(ReactApplicationContext context) {
 
@@ -89,6 +90,23 @@ public class AgoraModule extends ReactContextBaseJavaModule {
                 }
             });
 
+        }
+
+        // 接收到对方数据流消息的回调
+        @Override
+        public void onStreamMessage(final int uid, final int streamId, final byte[] data) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    String msg = new String(data);
+                    WritableMap map = Arguments.createMap();
+                    map.putString("type", "onStreamMessage");
+                    map.putInt("uid", uid);
+                    map.putInt("streamId", streamId);
+                    map.putString("data", msg);
+                    commonEvent(map);
+                }
+            });
         }
 
         /**
@@ -188,6 +206,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void init(ReadableMap options) {
         AgoraManager.getInstance().init(getReactApplicationContext(), mRtcEventHandler, options);
+        this.defaultStreamId = AgoraManager.getInstance().mRtcEngine.createDataStream(options.getBoolean("reliable"), options.getBoolean("ordered"));
     }
 
     //进入房间
@@ -345,6 +364,18 @@ public class AgoraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setDefaultAudioRouteToSpeakerphone(boolean defaultToSpeaker) {
         AgoraManager.getInstance().mRtcEngine.setDefaultAudioRoutetoSpeakerphone(defaultToSpeaker);
+    }
+
+    // 建立数据通道
+    @ReactMethod
+    public void createDataStream(boolean reliable, boolean ordered, Callback callback) {
+        callback.invoke(AgoraManager.getInstance().mRtcEngine.createDataStream(reliable, ordered));
+    }
+
+    // 发送数据
+    @ReactMethod
+    public void sendStreamMessage(int streamId, String message, Callback onError) {
+        onError.invoke(AgoraManager.getInstance().mRtcEngine.sendStreamMessage(streamId > 0 ? streamId : this.defaultStreamId, message.getBytes()));
     }
 
     //销毁引擎实例

--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -108,6 +108,24 @@ public class AgoraModule extends ReactContextBaseJavaModule {
             });
         }
 
+        // 接收对方数据流消息错误的回调
+        @Override
+        public void onStreamMessageError(final int uid, final int streamId, final int code, final int missed, final int cached) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    WritableMap map = Arguments.createMap();
+                    map.putString("type", "onStreamMessageError");
+                    map.putInt("uid", uid);
+                    map.putInt("streamId", streamId);
+                    map.putInt("error", code);
+                    map.putInt("missed", missed);
+                    map.putInt("cached", cached);
+                    commonEvent(map);
+                }
+            });
+        }
+
         /**
          * 说话声音音量提示回调
          */

--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -21,7 +21,6 @@ import io.agora.rtc.RtcEngine;
 import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 public class AgoraModule extends ReactContextBaseJavaModule {
-    private int defaultStreamId = -1;
 
     public AgoraModule(ReactApplicationContext context) {
 
@@ -206,7 +205,6 @@ public class AgoraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void init(ReadableMap options) {
         AgoraManager.getInstance().init(getReactApplicationContext(), mRtcEventHandler, options);
-        this.defaultStreamId = AgoraManager.getInstance().mRtcEngine.createDataStream(false, false);
     }
 
     //进入房间
@@ -375,7 +373,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
     // 发送数据
     @ReactMethod
     public void sendStreamMessage(int streamId, String message, Callback onError) {
-        onError.invoke(AgoraManager.getInstance().mRtcEngine.sendStreamMessage(streamId > 0 ? streamId : this.defaultStreamId, message.getBytes()));
+        onError.invoke(AgoraManager.getInstance().mRtcEngine.sendStreamMessage(streamId, message.getBytes()));
     }
 
     //销毁引擎实例

--- a/ios/RCTAgora/RCTAgora.m
+++ b/ios/RCTAgora/RCTAgora.m
@@ -34,6 +34,8 @@ RCT_EXPORT_MODULE();
     return @{};
 }
 
+NSInteger defaultDataStreamId = -1;
+
 /**
  *  初始化AgoraKit
  *
@@ -61,6 +63,9 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
     [self.rtcEngine enableVideo];
     [self.rtcEngine setVideoProfile:[options[@"videoProfile"] integerValue]swapWidthAndHeight:[options[@"swapWidthAndHeight"]boolValue]];
     [self.rtcEngine setClientRole:[options[@"clientRole"] integerValue] withKey:nil];
+
+    // 创建默认数据通道
+    [self.rtcEngine createDataStream:&dataChannelId reliable:0 ordered:0];
 
     //Agora Native SDK 与 Agora Web SDK 间的互通
     [self.rtcEngine enableWebSdkInteroperability:YES];

--- a/ios/RCTAgora/RCTAgora.m
+++ b/ios/RCTAgora/RCTAgora.m
@@ -34,8 +34,6 @@ RCT_EXPORT_MODULE();
     return @{};
 }
 
-NSInteger defaultDataStreamId = -1;
-
 /**
  *  初始化AgoraKit
  *
@@ -63,9 +61,6 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
     [self.rtcEngine enableVideo];
     [self.rtcEngine setVideoProfile:[options[@"videoProfile"] integerValue]swapWidthAndHeight:[options[@"swapWidthAndHeight"]boolValue]];
     [self.rtcEngine setClientRole:[options[@"clientRole"] integerValue] withKey:nil];
-
-    // 创建默认数据通道
-    [self.rtcEngine createDataStream:&dataChannelId reliable:0 ordered:0];
 
     //Agora Native SDK 与 Agora Web SDK 间的互通
     [self.rtcEngine enableWebSdkInteroperability:YES];
@@ -255,7 +250,7 @@ RCT_EXPORT_METHOD(createDataStream:(BOOL)reliable ordered:(BOOL)ordered callback
 发送数据流
 */
 RCT_EXPORT_METHOD(sendStreamMessage:(NSInteger)streamId data:(NSData*)data callback:(RCTResponseSenderBlock)callback){
-  int err = [self.rtcEngine sendStreamMessage:(streamId > 0 ? streamId : defaultDataStreamId) data:data];
+  int err = [self.rtcEngine sendStreamMessage:(streamId) data:data];
   callback(@[[NSNumber numberWithInteger:err]]);
 }
 

--- a/ios/RCTAgora/RCTAgora.m
+++ b/ios/RCTAgora/RCTAgora.m
@@ -47,13 +47,13 @@ RCT_EXPORT_MODULE();
  *  @return 0 when executed successfully. return negative value if failed.
  */
 RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
-    
+
     [AgoraConst share].appid = options[@"appid"];
-    
+
     self.rtcEngine = [AgoraRtcEngineKit sharedEngineWithAppId:options[@"appid"] delegate:self];
-    
+
     [AgoraConst share].rtcEngine = self.rtcEngine;
-    
+
     //频道模式
     [self.rtcEngine setChannelProfile:[options[@"channelProfile"] integerValue]];
     //启用双流模式
@@ -61,10 +61,10 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
     [self.rtcEngine enableVideo];
     [self.rtcEngine setVideoProfile:[options[@"videoProfile"] integerValue]swapWidthAndHeight:[options[@"swapWidthAndHeight"]boolValue]];
     [self.rtcEngine setClientRole:[options[@"clientRole"] integerValue] withKey:nil];
-    
+
     //Agora Native SDK 与 Agora Web SDK 间的互通
     [self.rtcEngine enableWebSdkInteroperability:YES];
-    
+
 }
 
 //加入房间
@@ -79,7 +79,7 @@ RCT_EXPORT_METHOD(leaveChannel){
     [self.rtcEngine leaveChannel:^(AgoraRtcStats *stat) {
         NSMutableDictionary *params = @{}.mutableCopy;
         params[@"type"] = @"onLeaveChannel";
-        
+
         [self sendEvent:params];
     }];
 }
@@ -117,7 +117,7 @@ RCT_EXPORT_METHOD(startPreview){
 //主播必须在加入频道前调用本章 API
 RCT_EXPORT_METHOD(configPublisher:(NSDictionary *)config){
     AgoraPublisherConfiguration *apc = [AgoraPublisherConfiguration new];
-    
+
     apc.width = [config[@"width"] integerValue];  //旁路直播的输出码流的宽度
     apc.height = [config[@"height"] integerValue]; //旁路直播的输出码流的高度
     apc.framerate = [config[@"framerate"] integerValue]; //旁路直播的输出码率帧率
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(configPublisher:(NSDictionary *)config){
     apc.rawStreamUrl = config[@"rawStreamUrl"]; //单流地址
     apc.extraInfo = config[@"extraInfo"]; //其他信息
     apc.owner = [config[@"owner"] boolValue]; //是否将当前主播设为该 RTMP 流的主人
-  
+
     [self.rtcEngine configPublisher:apc];
 }
 
@@ -237,6 +237,23 @@ RCT_EXPORT_METHOD(stopRecordingService:(NSString*)recordingKey){
     [self.rtcEngine stopRecordingService:recordingKey];
 }
 
+/*
+创建数据流
+*/
+RCT_EXPORT_METHOD(createDataStream:(BOOL)reliable ordered:(BOOL)ordered callback:(RCTResponseSenderBlock)callback){
+  NSInteger streamId = 0;
+  [self.rtcEngine createDataStream:&streamId reliable:reliable ordered:ordered];
+  callback(@[[NSNumber numberWithInteger:streamId]]);
+}
+
+/*
+发送数据流
+*/
+RCT_EXPORT_METHOD(sendStreamMessage:(NSInteger)streamId data:(NSData*)data callback:(RCTResponseSenderBlock)callback){
+  int err = [self.rtcEngine sendStreamMessage:(streamId > 0 ? streamId : defaultDataStreamId) data:data];
+  callback(@[[NSNumber numberWithInteger:err]]);
+}
+
 //获取版本号
 RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     callback(@[[AgoraRtcEngineKit getSdkVersion]]);
@@ -252,7 +269,7 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onError";
     params[@"err"] = [NSNumber numberWithInteger:errorCode];;
-    
+
     [self sendEvent:params];
 }
 
@@ -263,7 +280,7 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onWarning";
     params[@"err"] = [NSNumber numberWithInteger:warningCode];;
-    
+
     [self sendEvent:params];
 }
 
@@ -277,7 +294,7 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     params[@"type"] = @"onJoinChannelSuccess";
     params[@"uid"] = [NSNumber numberWithInteger:uid];
     params[@"channel"] = channel;
-    
+
     [self sendEvent:params];
 }
 
@@ -285,11 +302,11 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
  远端首帧视频接收解码回调
  */
 - (void)rtcEngine:(AgoraRtcEngineKit *)engine firstRemoteVideoDecodedOfUid:(NSUInteger)uid size:(CGSize)size elapsed:(NSInteger)elapsed {
-    
+
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onFirstRemoteVideoDecoded";
     params[@"uid"] = [NSNumber numberWithInteger:uid];
-    
+
     [self sendEvent:params];
 
 }
@@ -301,7 +318,7 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onUserJoined";
     params[@"uid"] = [NSNumber numberWithInteger:uid];
-    
+
     [self sendEvent:params];
 }
 
@@ -312,7 +329,7 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onUserOffline";
     params[@"uid"] = [NSNumber numberWithInteger:uid];
-    
+
     [self sendEvent:params];
 }
 
@@ -323,16 +340,42 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
 - (void)rtcEngine:(AgoraRtcEngineKit *)engine reportAudioVolumeIndicationOfSpeakers:(NSArray*)speakers totalVolume:(NSInteger)totalVolume {
     NSMutableDictionary *params = @{}.mutableCopy;
     params[@"type"] = @"onAudioVolumeIndication";
-    
+
     NSMutableArray *arr = [NSMutableArray array];
     for (AgoraRtcAudioVolumeInfo *obj in speakers) {
         [arr addObject:@{@"uid":[NSNumber numberWithInteger:obj.uid], @"volume":[NSNumber numberWithInteger:obj.volume]}];
     }
-    
+
     params[@"speakers"] = arr;
     params[@"totalVolume"] = [NSNumber numberWithInteger:totalVolume];
-    
+
     [self sendEvent:params];
+}
+
+/*
+接受数据流
+*/
+
+- (void)rtcEngine:(AgoraRtcEngineKit * _Nonnull)engine receiveStreamMessageFromUid:(NSUInteger)uid streamId:(NSInteger)streamId data:(NSData * _Nonnull)data{
+  NSMutableDictionary *params = @{}.mutableCopy;
+  params[@"type"] = @"onStreamMessage";
+  params[@"uid"] = [NSNumber numberWithInteger:uid];
+  params[@"streamId"] = [NSNumber numberWithInteger:streamId];
+  params[@"data"] = [[NSString alloc]initWithData:data encoding:NSUTF8StringEncoding];
+
+  [self sendEvent:params];
+}
+
+- (void)rtcEngine:(AgoraRtcEngineKit *)engine didOccurStreamMessageErrorFromUid:(NSUInteger)uid streamId:(NSInteger)streamId error:(NSInteger)error missed:(NSInteger)missed cached:(NSInteger)cached{
+  NSMutableDictionary *params = @{}.mutableCopy;
+  params[@"type"] = @"onStreamMessageError";
+  params[@"uid"] = [NSNumber numberWithInteger:uid];
+  params[@"streamId"] = [NSNumber numberWithInteger:streamId];
+  params[@"error"] = [NSNumber numberWithInteger:error];
+  params[@"missed"] = [NSNumber numberWithInteger:missed];
+  params[@"cached"] = [NSNumber numberWithInteger:cached];
+
+  [self sendEvent:params];
 }
 
 - (void)sendEvent:(NSDictionary *)params {
@@ -344,10 +387,10 @@ RCT_EXPORT_METHOD(getSdkVersion:(RCTResponseSenderBlock)callback){
 }
 
 //RCT_EXPORT_METHOD(getViewWithTag:(nonnull NSNumber *)reactTag) {
-//    
+//
 //    UIView *view = [self.bridge.uiManager viewForReactTag:reactTag];
 //    NSLog(@"%@",view);
-//    
+//
 //}
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-agora",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "声网Agora",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
新增 创建数据流通道，发送数据，监听接收数据 API 的封装，同时更新 README 说明文件以及版本号。

对 Java 和 Objective-C 都不是太懂，所以也就是照猫画虎的弄一下，仅通过简单测试，确认可以互相发送文本信息，任何其他疑问，欢迎回复讨论。

示范：
```
    sendStreamMessage(msg) {
        if (this.state.streamId === 0) {
            RtcEngine.createDataStream(false, false, streamId => {
                // streamId = parseInt(streamId, 10)
                console.log('创建 DataStream：', streamId, typeof streamId)
                if (streamId > 0) {
                    this.setState({streamId})
                    RtcEngine.sendStreamMessage(streamId, msg, err => {
                        console.log('发送信息结果：', err)
                    })
                }
            })
        } else {
            RtcEngine.sendStreamMessage(this.state.streamId, msg, err => {
                console.log('发送信息结果：', err)
            })
        }
    }
```