### PR TITLE
Marked variable muted as final to fix compilation issue

### DIFF
--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -223,7 +223,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
          * 用户mute音频回调
          */
         @Override
-        public void onUserMuteAudio(final int uid, boolean muted) {
+        public void onUserMuteAudio(final int uid, final boolean muted) {
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -240,7 +240,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
          * 用户mute视频回调
          */
         @Override
-        public void onUserMuteVideo(final int uid, boolean muted) {
+        public void onUserMuteVideo(final int uid, final boolean muted) {
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
There's an issue when compiling this library for Android.

`...local variable muted is accessed from within inner class; needs to be declared final...`

This pull request fixes this issue.