### PR TITLE
fix. android event remoteAudioStateChange

### DIFF
--- a/android/src/main/java/com/syan/agora/AgoraModule.java
+++ b/android/src/main/java/com/syan/agora/AgoraModule.java
@@ -664,7 +664,7 @@ public class AgoraModule extends ReactContextBaseJavaModule {
                     WritableMap map = Arguments.createMap();
                     map.putInt("uid", uid);
                     map.putInt("state", state);
-                    map.putInt("uid", reason);
+                    map.putInt("reason", reason);
                     map.putInt("elapsed", elapsed);
                     sendEvent(getReactApplicationContext(), AGRemoteAudioStateChanged, map);
                 }


### PR DESCRIPTION
fix typo that is setting `event.uid` to have the value for `reason` instead of the `uid`