### PR TITLE
Update RCTAgoraViewManager.m

### DIFF
--- a/ios/RCTAgora/RCTAgoraViewManager.m
+++ b/ios/RCTAgora/RCTAgoraViewManager.m
@@ -22,7 +22,11 @@ RCT_CUSTOM_VIEW_PROPERTY(showLocalVideo, BOOL, RCTAgoraVideoView) {
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(remoteUid, NSInteger, RCTAgoraVideoView) {
-  view.remoteUid = [RCTConvert NSInteger:json];
+  if ([json isKindOfClass:[NSString class]]) {
+    view.remoteUid = [[RCTConvert NSString:json] integerValue];
+  } else {
+    view.remoteUid = [RCTConvert NSInteger:json];
+  }
 }
 
 - (UIView *)view {


### PR DESCRIPTION

crash fix: remote Uid was coming as NSString from API, converting it to Integer if required





![crash-remoteuid](https://user-images.githubusercontent.com/25710854/78560554-e6db0500-7833-11ea-9841-7428bd56486a.jpeg)
