### PR TITLE
Enable autolinking 

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,6 @@
     "tslib": "^1.9.3"
   },
    "files": [
-    "android",
-    "ios",
-    "lib",
     "react-native-agora.podspec"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -74,5 +74,7 @@
   "dependencies": {
     "tslib": "^1.9.3"
   },
-  
+     "files": [
+    "react-native-agora.podspec"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
    "files": [
     "android",
     "ios",
+    "lib",
+    "index.js",
     "react-native-agora.podspec"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "tslib": "^1.9.3"
   },
      "files": [
-    "react-native-agora.podspec",
+    "react-native-agora.podspec"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "android",
     "ios",
     "lib",
-    "index.js",
     "react-native-agora.podspec"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -75,8 +75,6 @@
     "tslib": "^1.9.3"
   },
      "files": [
-    "react-native-agora.podspec", 
-    "android",
-    "ios",
+    "react-native-agora.podspec",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "tslib": "^1.9.3"
   },
      "files": [
-    "react-native-agora.podspec"
+    "react-native-agora.podspec", 
+    "android",
+    "ios",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,5 @@
   "dependencies": {
     "tslib": "^1.9.3"
   },
-   "files": [
-    "react-native-agora.podspec"
-  ]
+  
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,10 @@
   },
   "dependencies": {
     "tslib": "^1.9.3"
-  }
+  },
+   "files": [
+    "android",
+    "ios",
+    "react-native-agora.podspec"
+  ]
 }


### PR DESCRIPTION
As of React Native 0.60, native modules are linked automatically => https://reactnative.dev/blog/2019/07/03/version-60#native-modules-are-now-autolinked

To enable autolinking on this project, we just need to whitelist the **_react-native-agora.podspec_** file in root _**package.json**_. After that, react-native-agora will be linked automatically upon npm install. 