### PR TITLE
Fix Xcode 12 Compatibility

### DIFF
--- a/react-native-agora.podspec
+++ b/react-native-agora.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     s.source         = { :git => package["repository"]["url"] }
     s.source_files   = 'ios/RCTAgora/**/*.{h,m,swift}'
 
-    s.dependency 'React'
+    s.dependency 'React-Core'
     s.dependency "AgoraRtcEngine_iOS_Crypto", "3.0.1.1"
 end


### PR DESCRIPTION
Xcode 12 (released on Sept 16) fails to build without the module being liked to `React-Core` directly. This change is needed for React Native 0.60.2 or newer for iOS
Ref: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116