### PR TITLE
Fix iOS crash in getErrorDescription

### DIFF
--- a/ios/RCTAgora/Base/RtcEngine.swift
+++ b/ios/RCTAgora/Base/RtcEngine.swift
@@ -1045,7 +1045,7 @@ class RtcEngineManager: NSObject, RtcEngineInterface {
     }
 
     @objc func getErrorDescription(_ params: NSDictionary, _ callback: Callback) {
-        callback.success(AgoraRtcEngineKit.getErrorDescription((params["code"] as! NSNumber).intValue))
+        callback.success(AgoraRtcEngineKit.getErrorDescription((params["error"] as! NSNumber).intValue))
     }
 
     @objc func enableDeepLearningDenoise(_ params: NSDictionary, _ callback: Callback) {


### PR DESCRIPTION
When I call `RtcEngine.getErrorDescription(110)` (or any error code number) on iOS, the app hard crashes. Xcode gives this log message:

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value: file react_native_agora/RtcEngine.swift, line 1048
```

This PR fixes the parameter name that the Swift implementation is using. The Java implementation is already using `error` and works.