### PR TITLE
fix: warnings after RN 0.65 upgrade

### DIFF
--- a/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcChannelModule.kt
+++ b/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcChannelModule.kt
@@ -48,6 +48,16 @@ class RCTAgoraRtcChannelModule(
   }
 
   @ReactMethod
+  fun addListener(eventName: String) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  fun removeListeners(count: Number) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
   fun callMethod(methodName: String, params: ReadableMap?, callback: Promise?) {
     manager.javaClass.declaredMethods.find { it.name == methodName }?.let { function ->
       function.let { method ->

--- a/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcChannelModule.kt
+++ b/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcChannelModule.kt
@@ -53,7 +53,7 @@ class RCTAgoraRtcChannelModule(
   }
 
   @ReactMethod
-  fun removeListeners(count: Number) {
+  fun removeListeners(count: Int) {
     // Keep: Required for RN built in Event Emitter Calls.
   }
 

--- a/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcEngineModule.kt
+++ b/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcEngineModule.kt
@@ -48,7 +48,7 @@ class RCTAgoraRtcEngineModule(
   }
 
   @ReactMethod
-  fun removeListeners(count: Number) {
+  fun removeListeners(count: Int) {
     // Keep: Required for RN built in Event Emitter Calls.
   }
 

--- a/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcEngineModule.kt
+++ b/android/src/main/java/io/agora/rtc/react/RCTAgoraRtcEngineModule.kt
@@ -43,6 +43,16 @@ class RCTAgoraRtcEngineModule(
   }
 
   @ReactMethod
+  fun addListener(eventName: String) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  fun removeListeners(count: Number) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
   fun callMethod(methodName: String, params: ReadableMap?, callback: Promise?) {
     manager.javaClass.declaredMethods.find { it.name == methodName }?.let { function ->
       function.let { method ->


### PR DESCRIPTION
React Native 0.65 requires new functions to be added for its new listeners. Check for https://github.com/react-native-netinfo/react-native-netinfo/pull/487 to see more details. iOS part is not necessary right now.