### PR TITLE
fix: improve Xcode 12 support

### DIFF
--- a/react-native-agora.podspec
+++ b/react-native-agora.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.swift_version = "4.0"
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "AgoraRtcEngine_iOS", "3.5.2"
 end


### PR DESCRIPTION
We should depend on `React-Core` instead of `React` according to https://github.com/facebook/react-native/issues/29633#issuecomment-694187116. You can check all the related PRs links to this issue.