### PR TITLE
feat: enable buildFeatures.buildConfig for android gradle plugin 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,9 @@ def supportsNamespace() {
 android {
   if (supportsNamespace()) {
     namespace "io.agora.rtc.ng.react"
-
+    buildFeatures {
+      buildConfig true
+    }
     sourceSets {
       main {
         manifest.srcFile "src/main/AndroidManifestNew.xml"


### PR DESCRIPTION
Add support for RN 0.73.
Similar to https://github.com/th3rdwave/react-native-safe-area-context/pull/455